### PR TITLE
Update contact section

### DIFF
--- a/index.html
+++ b/index.html
@@ -236,7 +236,7 @@
               <div class="col-lg-8 col-lg-offset-2">
                 <div class="wow bounceInDown" data-wow-delay="0.4s">
                   <div class="section-heading">
-                    <h2>Contact the ACSU</h2>
+                    <h2>Contact ACSU</h2>
                   </div>
                 </div>
               </div>
@@ -253,9 +253,11 @@
             <div class="col-lg-2">
             </div>
             <div class="col-lg-8">
-              <h5>Contact our officers at acsu@cornell.edu.</h5>
-              <h5>Our mailing list is acsu-l@cornell.edu.</h5>
-              <p><strong>Learn more about our mailing list <a href="http://www.it.cornell.edu/services/elist/howto/user/join.cfm">here</a></strong>. &nbsp;We use our mailing list to notify ACSU members of relevant opportunities (i.e. internships/jobs), our upcoming events, and other events of interest in the Cornell Engineering community. You can use the form below to subscribe to join our general mailing list. Anyone is welcome to join at no cost.</p>
+              <h4>Questions?</h4>
+              <p>Contact our officers at <strong><a href="mailto:acsu@cornell.edu">acsu@cornell.edu</a></strong>, or <strong><a href="https://www.facebook.com/CornellACSU">shoot us a message on Facebook</a></strong>.
+              <br/><br/>
+              <h4>Mailing List</h4>
+              <p>Join our mailing list to get notified about relevant opportunities (e.g. internships/jobs), our upcoming events, and other events of interest in the Cornell Engineering community. Anyone is welcome to join at no cost. Just fill in your email below to subscribe! </p>
               <!-- Mailing List Subscription Form -->
               <form id="mailing_signup" action="https://www.list.cornell.edu/subscribe/subscribe.tml" method="POST">
                 <input class="form-control" type="text" name="email" value="" SIZE=18 placeholder="Email Address">
@@ -276,9 +278,13 @@
                 <input type="hidden" name="secx" value="111f3785">
               </form>
               <!-- End Mailing List Subscription Form -->
+              <br/><br/>
+              <h4>Membership</h4>
               <p>
-                Paid ACSU membership is open to all Cornell Undergraduate students. Members receive a t-shirt, are invited to submit their resumes to our resume book, and enjoy many other benefits. To join the ACSU, attend and sign in at least one general meeting and pay the annual dues of only $5. Membership is not required to subscribe to our mailing list.
-                <br><br>
+                Paid ACSU membership is open to all Cornell undergraduate students. Members receive a t-shirt, are invited to submit their resumes to our resume book, and enjoy many other benefits. To join ACSU, attend and sign in at least one general meeting and pay the annual dues of only $5. Membership is not required to subscribe to our mailing list.
+                <br/><br/>
+                Come to our <strong><a href="https://www.facebook.com/events/241344616393938/">first general body meeting</a></strong> of the semester on <strong>Tuesday, September 19</strong>!
+                <br/><br/>
                 <i>Note that ACSU membership lasts for an academic school year, regardless of which semester you paid. For instance, if you pay your dues anytime in Fall 2017 or Spring 2018, you will be an ACSU paid member until the end of the Spring 2018 semester.</i>
               </p>
               <br>

--- a/index.html
+++ b/index.html
@@ -257,7 +257,7 @@
               <p>Contact our officers at <strong><a href="mailto:acsu@cornell.edu">acsu@cornell.edu</a></strong>, or <strong><a href="https://www.facebook.com/CornellACSU">shoot us a message on Facebook</a></strong>.
               <br/><br/>
               <h4>Mailing List</h4>
-              <p>Join our mailing list to get notified about relevant opportunities (e.g. internships/jobs), our upcoming events, and other events of interest in the Cornell Engineering community. Anyone is welcome to join at no cost. Just fill in your email below to subscribe! </p>
+              <p><strong>Join our mailing list</strong> to get notified about relevant opportunities (e.g. internships/jobs), our upcoming events, and other events of interest in the Cornell Engineering community. Anyone is welcome to join at no cost. Just fill in your email below to subscribe! </p>
               <!-- Mailing List Subscription Form -->
               <form id="mailing_signup" action="https://www.list.cornell.edu/subscribe/subscribe.tml" method="POST">
                 <input class="form-control" type="text" name="email" value="" SIZE=18 placeholder="Email Address">


### PR DESCRIPTION
temporary quick fix for ease of use

- Reword contact info and add Facebook link
- Reword mailing list blurb
- "the ACSU" -> "ACSU"
- Add link to first gbody Facebook event

old vs new:
![image](https://user-images.githubusercontent.com/8212590/30413444-06e64906-98ec-11e7-866a-39514039fb5d.png)

