### PR TITLE
Don't use weird link color on focus (in calendar)

### DIFF
--- a/calendar.html
+++ b/calendar.html
@@ -6,7 +6,10 @@ permalink: calendar.html
 <script>
 $(".navbar-custom").css('background-color', '#272940');
 </script>
-<style type='text/css'> .event-location { font-weight: bold; font-style: italic; display: block } </style>
+<style type='text/css'>
+.event-location { font-weight: bold; font-style: italic; display: block }
+a.fc-event:focus { color: white; }
+</style>
 
 <!-- Section: calendar -->
 


### PR DESCRIPTION
When you focus on a calendar link, it currently turns the normal focus color (#176e61). But this is inappropriate when the link is against a dark background (that is, #3a87ad). This PR makes the focus color white instead.