### PR TITLE
Purging "Programs" and "Workshops"

### DIFF
--- a/_data/navigation.yml
+++ b/_data/navigation.yml
@@ -12,19 +12,8 @@
   sublinks:
   - title: Calendar
     url: calendar.html
-  # - title: Corporate
-  #   url: /corporate.html
   - title: G-Body
     url: gbody.html
-  - title: Workshops
-    url: workshops.html
-- title: Programs
-  url: programs.html
-  sublinks:
-    - title: Mentorship
-      url: mentorship.html
-    - title: Reading Groups
-      url: reading.html
 - title: Resources
   url: resources.html
   sublinks:


### PR DESCRIPTION
At the request of Jerry, remove both pages under "Programs":
- Reading Groups, since they don't exist anymore
- Mentorship, since it doesn't direct anywhere to how to actually sign up for mentorship and will be reworked later into its own page

also removed Workshops, since we only had two and don't have anymore for the foreseeable future